### PR TITLE
Update `ethereum-consensus` source from `risc0-labs` to `boundless` org

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/boundless/ethereum-consensus.git?rev=b60278d73cdfc871f17e06493f707a034f3599cb#b60278d73cdfc871f17e06493f707a034f3599cb"
+source = "git+https://github.com/boundless-xyz/ethereum-consensus.git?rev=b60278d73cdfc871f17e06493f707a034f3599cb#b60278d73cdfc871f17e06493f707a034f3599cb"
 dependencies = [
  "blst",
  "bs58",
@@ -6793,7 +6793,7 @@ source = "git+https://github.com/boundless-xyz/Signal-Ethereum?tag=v1.0.0#c48718
 dependencies = [
  "alloy-primitives",
  "bitvec",
- "ethereum-consensus 0.1.1 (git+https://github.com/boundless/ethereum-consensus.git?rev=b60278d73cdfc871f17e06493f707a034f3599cb)",
+ "ethereum-consensus 0.1.1 (git+https://github.com/boundless-xyz/ethereum-consensus.git?rev=b60278d73cdfc871f17e06493f707a034f3599cb)",
  "itertools 0.14.0",
  "rayon",
  "risc0-zkvm",


### PR DESCRIPTION
Update `ethereum-consensus` source from `risc0-labs` to `boundless` org